### PR TITLE
fix: Create backup folder for elfbot backup symlinks

### DIFF
--- a/charts/myprecious/templates/configmaps/configmap-filebrowser-elfbot.yaml
+++ b/charts/myprecious/templates/configmaps/configmap-filebrowser-elfbot.yaml
@@ -93,6 +93,7 @@ data:
             if [[ "$2" == "symlinks" ]]; then
                 TIMESTAMP=$(printf '%(%Y-%m-%d--%H-%M)T\n' -1)
                 echo "Backing up all symlinks to /storage/elfstorage/backup/symlinks-$TIMESTAMP.tar.gz"
+                mkdir -p /storage/elfstorage/backup/
                 tar -C /storage/symlinks -czf /storage/elfstorage/backup/symlinks-$TIMESTAMP.tar.gz .
                 BACKUP_SIZE=$(du -sh /storage/elfstorage/backup/symlinks-$TIMESTAMP.tar.gz | awk '{print $1}')
                 echo "Done! (yes, it really was that fast!) - total size 🔬 $BACKUP_SIZE "


### PR DESCRIPTION
I was getting this error when using `elfbot backup symlinks` for the first time. 

```
$ elfbot backup symlinks

Backing up all symlinks to /storage/elfstorage/backup/symlinks-2024-06-20--18-04.tar.gz
Done! (yes, it really was that fast!) - total size 🔬  
tar (child): /storage/elfstorage/backup/symlinks-2024-06-20--18-04.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: /storage/elfstorage/backup/symlinks-2024-06-20--18-04.tar.gz: Cannot write: Broken pipe
tar: Child returned status 2
tar: Error is not recoverable: exiting now
du: cannot access '/storage/elfstorage/backup/symlinks-2024-06-20--18-04.tar.gz': No such file or directory
```

Creating the `/storage/elfstorage/backup` directory addresses this.